### PR TITLE
Pack Filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12619,6 +12619,11 @@
         "warning": "^4.0.3"
       }
     },
+    "react-multi-select-component": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/react-multi-select-component/-/react-multi-select-component-4.1.12.tgz",
+      "integrity": "sha512-2RudkAFCiBzVMylbkhaFdjrCo3l1i0K2kFOk07qUq5HEFyUvS70Oj02DRLD2nkvlb71nX5gHofFeXCqRHr1olg=="
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-modal": "^3.14.3",
+    "react-multi-select-component": "^4.1.12",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,10 @@ export interface SearchResponse extends IBaseResponse {
   data: PrefabsWrapper
 }
 
+export interface PackResponse extends IBaseResponse {
+  data: Array<IPack>
+}
+
 export interface IBaseResponse {
   success: boolean
   message?: string
@@ -26,4 +30,4 @@ export interface Category {
 }
 
 export type PrefabsWrapper = Record<string, { pack: IPack, prefabs: Array<IPrefab>, active: boolean }>
-export type Categories = { active: Category | null, categories: Array<Category> } 
+export type Categories = { active: Category | null, categories: Array<Category> }

--- a/src/services/prefabService.ts
+++ b/src/services/prefabService.ts
@@ -2,10 +2,14 @@ import { AxiosResponse } from 'axios'
 import { union } from 'lodash'
 import http from './httpService'
 // import { groupBy, mapValues, map } from 'lodash'
-import { SearchResponse, PrefabsWrapper, Categories } from '../models'
+import { SearchResponse, PrefabsWrapper, Categories, PackResponse } from '../models'
 
 export const getPrefabs = async (query: string): Promise<AxiosResponse<SearchResponse>> => {
   return await http.get<SearchResponse>(`/prefab/search/${query}`)
+}
+
+export const getPacks = async (): Promise<AxiosResponse<PackResponse>> => {
+  return await http.get<PackResponse>(`/prefab/packs`)
 }
 
 export const getCategories = (wrapper: PrefabsWrapper): Categories => {

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -4,6 +4,7 @@ export default {
     yellow: '#f8dc41',
     brown: '#F2994A',
     black: '#000000',
+    grey: '#ababab',
     error: 'red'
   },
   font: {

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -14,7 +14,7 @@ import { AxiosResponse } from 'axios'
 
 import logo from './../../assets/logo.png'
 
-type OptionType = InstanceType<typeof Option>;
+type OptionType = InstanceType<typeof Option>
 
 interface PrefabProps {
   imagePath: string
@@ -65,8 +65,8 @@ const HomeView = (): JSX.Element => {
   const [categories, setCategories] = useState<Categories | null>(null)
   const [activePrefab, setActivePrefab] = useState<IPrefab | null>(null)
   const [errorState, setErrorState] = useState<{ hasError: boolean, errorMessage: string }>(DEFAULT_ERROR_STATE)
-  const [selectedPacks, setSelectedPacks] = useState<OptionType[]>([])
-  const [filteredPackIdentifiers, setFilteredPackIdentifiers] = useState<string[]>([])
+  const [selectedPacks, setSelectedPacks] = useState<Array<OptionType>>([])
+  const [filteredPackIdentifiers, setFilteredPackIdentifiers] = useState<Array<string>>([])
   const [packNames, setPackNames] = useState<Array<OptionType>>([])
   const [cachedResponse, setCachedResponse] = useState<AxiosResponse<SearchResponse>>()
 
@@ -87,7 +87,7 @@ const HomeView = (): JSX.Element => {
   }, [categories])
 
   useEffect(() => {
-    handleGetPacks();
+    handleGetPacks()
   }, [])
 
   useEffect(() => {
@@ -95,21 +95,25 @@ const HomeView = (): JSX.Element => {
   }, [selectedPacks])
 
   const handleGetPacks = async () => {
-    const packs = await getPacks();
+    const packs = await getPacks()
 
     if (packs.data.success) {
       setPackNames(packs.data.data.map<OptionType>((elem) => {
-        return { label: elem.name.substring(POLYGON_PREFIX_LENGTH), value: elem.identifier } as OptionType
+        return {
+          label: elem.name.substring(POLYGON_PREFIX_LENGTH),
+          value: elem.identifier
+        } as OptionType
       }, packNames))
 
-      const previousSelection = localStorage.getItem(PACK_SELECTION_LOCAL_STORAGE_KEY);
+      const previousSelection = localStorage.getItem(PACK_SELECTION_LOCAL_STORAGE_KEY)
 
-      if (previousSelection)
+      if (previousSelection) {
         setSelectedPacks(JSON.parse(previousSelection))
+      }
     }
   }
 
-  const handlePackSelectionChanges = (selection: OptionType[]) => {
+  const handlePackSelectionChanges = (selection: Array<OptionType>) => {
     setSelectedPacks(selection)
     localStorage.setItem(PACK_SELECTION_LOCAL_STORAGE_KEY, JSON.stringify(selection))
   }
@@ -119,21 +123,24 @@ const HomeView = (): JSX.Element => {
     const filteredPacks: PrefabsWrapper = {}
     const remainingPacks: PrefabsWrapper = {}
 
-    Object.values(cachedResponse!.data.data).
-      forEach((elem) => {
-        packs.includes(elem.pack.identifier) ?
-          filteredPacks[elem.pack.identifier] = elem :
-          remainingPacks[elem.pack.identifier] = elem
-      })
+    Object.values(cachedResponse!.data.data).forEach((elem) => {
+      packs.includes(elem.pack.identifier)
+        ? filteredPacks[elem.pack.identifier] = elem
+        : remainingPacks[elem.pack.identifier] = elem
+    })
 
-    return [{ ...filteredPacks, ...remainingPacks }, filteredPacks]
+    return [
+      { ...filteredPacks, ...remainingPacks },
+      filteredPacks
+    ]
   }
 
   const displayFilteredPacks = () => {
-    if (!cachedResponse)
+    if (!cachedResponse) {
       return
+    }
 
-    const [combinedPacks, filteredPacks] = getFilteredPacks();
+    const [combinedPacks, filteredPacks] = getFilteredPacks()
     setFilteredPackIdentifiers(Object.keys(filteredPacks))
 
     setPrefabs(combinedPacks)
@@ -194,6 +201,7 @@ const HomeView = (): JSX.Element => {
 
   const onInputChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     const correctLength = isQueryCorrectLength(event.currentTarget.value)
+
     if (!correctLength) {
       handleQueryTooShort()
     } else {
@@ -319,12 +327,12 @@ const HomeView = (): JSX.Element => {
         <Home.Search onClick={() => handleSearchClicked()}>Search</Home.Search>
       </Home.Top>
       <Home.Bottom>
-        <Home.SwitchTransition mode="out-in">
+        <Home.SwitchTransition mode='out-in'>
           <Home.Transition
             key={`state-${isFetching}`}
             in={isFetching}
-            classNames="fade"
-            component="div"
+            classNames='fade'
+            component='div'
             timeout={150}>
             {
               isFetching && prefabs
@@ -338,12 +346,6 @@ const HomeView = (): JSX.Element => {
         <Home.FooterRow>
           by community for community
         </Home.FooterRow>
-        {/* <Home.FooterRow>
-          you can show me some <Home.Icon icon={faHeart} /> and buy me a
-          <Home.Link href={'https://www.paypal.com/donate/?business=novacik.daniel%40gmail.com&no_recurring=0&currency_code=EUR'} target='_blank'>
-            <Home.Icon icon={faCoffee} />
-          </Home.Link>
-        </Home.FooterRow> */}
         <Home.FooterSignature>
           made with <Home.Icon icon={faHeart} color='red' /> by
           <Home.Link href={'https://cognision.eu'} target='_blank'>@ra6e</Home.Link>
@@ -374,8 +376,8 @@ const HomeView = (): JSX.Element => {
         </Home.Details>
       }
     </Home.Layout >
-  );
-};
+  )
+}
 
 const Home = {
   Layout: Styled.div`

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -13,7 +13,6 @@ import { MultiSelect } from 'react-multi-select-component'
 import { AxiosResponse } from 'axios'
 
 import logo from './../../assets/logo.png'
-import theme from '../../theme/theme'
 
 type OptionType = InstanceType<typeof Option>;
 

--- a/src/views/Home/index.tsx
+++ b/src/views/Home/index.tsx
@@ -58,7 +58,7 @@ const HomeView = (): JSX.Element => {
   const [categories, setCategories] = useState<Categories | null>(null)
   const [activePrefab, setActivePrefab] = useState<IPrefab | null>(null)
   const [errorState, setErrorState] = useState<{ hasError: boolean, errorMessage: string }>(DEFAULT_ERROR_STATE)
-  const [selectedValues, setSelectedValues] = useState([]);
+  const [selectedValues, setSelectedValues] = useState<OptionType[]>([]);
   const [filteredPackIdentifiers, setFilteredPackIdentifiers] = useState<string[]>([]);
   const [packNames, setPackNames] = useState<OptionType[]>([]);
 
@@ -89,7 +89,16 @@ const HomeView = (): JSX.Element => {
       setPackNames(packs.data.data.map<OptionType>((elem) => {
         return { label: elem.name.substring('Polygon'.length), value: elem.identifier } as OptionType
       }, packNames));
+
+      const previousSelection = localStorage.getItem("packSelection");
+      if (previousSelection)
+        setSelectedValues(JSON.parse(previousSelection))
     }
+  }
+
+  const handlePackSelectionChanges = (selection: OptionType[]) => {
+    setSelectedValues(selection)
+    localStorage.setItem("packSelection", JSON.stringify(selection))
   }
 
   const handleSearchClicked = async () => {
@@ -281,7 +290,7 @@ const HomeView = (): JSX.Element => {
         <Home.MultiSelect
           options={packNames}
           value={selectedValues}
-          onChange={setSelectedValues}
+          onChange={handlePackSelectionChanges}
           labelledBy="Select"
           overrideStrings={{ 'selectSomeItems': "All Packs" }}
         />


### PR DESCRIPTION
This PR adds the ability to filter the search results based on selected packs. The packs that the user selects will be pushed to the top and all other packs will get send to the bottom and be given a gray header to indicate that they were not filtered but still had relevant results. The selection will be stored in the user's local storage to avoid them having to re-select their desired packs every time they visit the website